### PR TITLE
用timerfd实现非阻塞的sleep()/usleep()/nanosleep()

### DIFF
--- a/include/hook_greenify.h
+++ b/include/hook_greenify.h
@@ -25,6 +25,9 @@ typedef enum
     FN_SENDTO,
     FN_SELECT,
     FN_POLL,
+    FN_SLEEP,
+    FN_USLEEP,
+    FN_NANOSLEEP,
 } greenified_function_t;
 
 void* greenify_patch_lib(const char* library_filename, greenified_function_t fn);

--- a/include/libgreenify.h
+++ b/include/libgreenify.h
@@ -36,6 +36,9 @@ int green_select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds,
 #ifndef NO_POLL
 int green_poll(struct pollfd *fds, nfds_t nfds, int timeout);
 #endif
+unsigned int green_sleep(unsigned int seconds);
+int green_usleep(useconds_t usec);
+int green_nanosleep(const struct timespec *duration, struct timespec *rem);
 
 struct greenify_watcher {
 	int fd;

--- a/src/hook_greenify.c
+++ b/src/hook_greenify.c
@@ -38,6 +38,12 @@ void* greenify_patch_lib(const char* library_filename, greenified_function_t fn)
         case FN_POLL:
             return _GREENIFY_PATCH_EXPAND(library_filename, poll);
 #endif
+        case FN_SLEEP:
+            return _GREENIFY_PATCH_EXPAND(library_filename, sleep);
+        case FN_USLEEP:
+            return _GREENIFY_PATCH_EXPAND(library_filename, usleep);
+        case FN_NANOSLEEP:
+            return _GREENIFY_PATCH_EXPAND(library_filename, nanosleep);
         default:
             return NULL;
     }


### PR DESCRIPTION
我用到的一个c库除了网络IO block，还有sleep()等其他block，所以我fork了greenify来实现非阻塞的sleep。原理是把常用的sleep()函数替换为timerfd，加入事件循环，监听read()。
（未解决信号中断sleep的问题）

用法：patch_lib()增加了个默认参数：patch_sleep=False，默认不patch sleep()
如需patch：
`greenify.patch_lib('/usr/lib/libmemcached.so', patch_sleep=True)`