### PR TITLE
chore: build wheel with limited api

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,6 @@
 name: publish
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,9 @@
 name: publish
 
-on:
-  push:
-    tags:
-      - v*
+on: [push]
 
 jobs:
-  pypi:
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -15,18 +12,80 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
+    - name: Install python dependencies
+      run: pip install Cython auditwheel
     - name: Build a source tarball
       run: python setup.py sdist
-    - name: Build wheels
-      uses: RalfG/python-wheels-manylinux-build@v0.4.2-manylinux2014_x86_64
-      with:
-        python-versions: 'cp39-cp39 cp310-cp310 cp311-cp311 cp312-cp312 cp313-cp313 cp314-cp314'
-        build-requirements: 'cython'
-    - name: Clean linux_x86_64.whl
-      run: rm dist/*-linux_x86_64.whl
+    - name: Build Wheel
+      run: python setup.py bdist_wheel --py-limited-api=cp39
+    - name: Repair Wheel
+      run: find dist -name *.whl -print -exec auditwheel repair {} \;
+    - name: Clean Non Audited Wheel
+      run: rm -v dist/*-linux_x86_64.whl
     - name: Check build result
-      run: ls -lh dist/
+      run: |
+        ls -lh dist
+        find dist -name *.tar.gz -print -exec tar -ztvf {} \;
+        ls -lh wheelhouse
+        find wheelhouse -name *.whl -print -exec unzip -l {} \;
+    - uses: actions/upload-artifact@v4
+      with:
+        name: wheel
+        path: wheelhouse/*.whl
+    - uses: actions/upload-artifact@v4
+      with:
+        name: sdist
+        path: dist/*.tar.gz
+
+  test:
+    needs: [build]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        pyver: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        # only checkout files for test
+        sparse-checkout: |
+          tests
+          misc/test.sh
+    - uses: actions/download-artifact@v4
+      with:
+        name: wheel
+        path: wheel
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.pyver }}
+    - name: Install python dependencies
+      run: |
+        pip install gevent
+        pip install wheel/*.whl
+    - name: Run test
+      run: misc/test.sh
+
+  pypi:
+    needs: [build, test]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@v4
+      with:
+        name: wheel
+        path: dist
+    - uses: actions/download-artifact@v4
+      with:
+        name: sdist
+        path: dist
+    - name: dump result
+      run: |
+        ls -lh dist
+        find dist -name *.whl -print -exec unzip -l {} \;
+        find dist -name *.tar.gz -print -exec tar -ztvf {} \;
     - name: Publish to PyPI
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         skip_existing: true

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,22 @@
 from glob import glob
 from setuptools import setup, Extension
 
-version = "0.4.4"
+version = "0.5.0"
 
 
 def readme():
     with open("README.rst") as f:
         return f.read()
+
+
+def make_limited_api_macro(version):
+    s = 0
+    step = 8
+    pos = step * 3
+    for i in version.split("."):
+        s += int(i) << pos
+        pos -= step
+    return s
 
 
 include_dirs = ["include"]
@@ -50,6 +60,10 @@ setup(
             sources,
             include_dirs=include_dirs,
             libraries=libraries,
+            define_macros=[
+                ("Py_LIMITED_API", make_limited_api_macro("3.9")),
+            ],
+            py_limited_api=True,
         )
     ],
 )


### PR DESCRIPTION
### Step 1: Standard bdist wheel command

Running the standard bdist_wheel command:

    python setup.py bdist_wheel

produces a platform-specific wheel with a filename like:

    greenify-0.5.0-cp39-cp39-linux_x86_64.whl

Attempting to install this wheel on a different Python minor version, such as Python 3.10, results in a platform compatibility error:

    ERROR: greenify-0.5.0-cp39-cp39-linux_x86_64.whl is not a supported wheel on this platform.

### Step 2: Adding limited api Flag

Adding the `--py-limited-api` parameter to the bdist_wheel command:

    python setup.py bdist_wheel --py-limited-api=cp39

produces an ABI3 wheel package with a more compatible filename:

    greenify-0.5.0-cp39-abi3-linux_x86_64.whl

However, the name of the compiled shared object (.so) file inside the wheel package is still incorrect:

    greenify.cpython-39-x86_64-linux-gnu.so

While the wheel installs successfully on Python 3.10,
running tests raises an ImportError because the module cannot be found under the expected ABI-stable name:

    ModuleNotFoundError: No module named 'greenify'

### Step 3: Configuring Limited API in setup.py

The correct solution is to explicitly define the Limited API settings within the Extension configuration in setup.py:

    setup(
        ext_modules=[
            Extension(
                define_macros=[
                    ("Py_LIMITED_API", make_limited_api_macro("3.9")),
                ],
                py_limited_api=True, 
            )
        ]
    )

This configuration ensures that both the wheel package name and the internal shared object file name are correct for ABI3 compatibility:

Correct Wheel Name:

    greenify-0.5.0-cp39-abi3-linux_x86_64.whl

Correct .so File Name:

    greenify.abi3.so

This wheel can now be installed and tested successfully across the specified range of target Python versions, from Python 3.9 to Python 3.14.